### PR TITLE
🐛 Fix query for manga profile statistics

### DIFF
--- a/internal/profile.go
+++ b/internal/profile.go
@@ -34,7 +34,7 @@ func (p *Profile) Get() error {
                 }
                 manga {
                     count
-                    minutesWatched
+                    chaptersRead
                 }
             }
             siteUrl


### PR DESCRIPTION
- Change `minutesWatched` to `chaptersRead`