### PR TITLE
✨ Add support for MacOS in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
+
 if [ "$(id -u)" -ne 0 ]; then
     echo "This script must be run as root or with sudo."
     exit 1
 fi
 
+
+PLATFORM=$(uname | tr "[:upper:]" "[:lower:]")
+ARCHITECTURE=$(uname -m | sed -e "s/^x86_64$/amd64/" -e "s/^aarch64$/arm64/")
+OS_ARCH=$(echo "$PLATFORM"_"$ARCHITECTURE")
 REPO_URL="https://api.github.com/repos/CosmicPredator/chibi-cli/releases/latest"
 BINARY_NAME="chibi"
 INSTALL_PATH="/usr/local/bin/$BINARY_NAME"
-CONFIG_DIR="/home/$SUDO_USER/.config/chibi"
-OS_ARCH="linux_amd64"
 
 install_binary() {
+
+    echo "Platform: $PLATFORM Arch: $ARCHITECTURE"
+
+    if [ "$PLATFORM" == "darwin" ] && ! command -v jq > /dev/null 2>&1; then
+        tools_path=$(xcode-select -p 2>/dev/null)
+        if [ -z "$tools_path" ]; then
+            echo "Error: Either install jq or enable command line tools. To enable command line tools run  'xcode-select --install'"
+            exit 1
+        fi
+    fi
+
     echo "Fetching the latest release information..."
 
     if command -v curl > /dev/null 2>&1; then
@@ -22,7 +36,13 @@ install_binary() {
         exit 1
     fi
 
-    DOWNLOAD_URL=$(echo "$RELEASE_INFO" | jq -r ".assets[] | select(.name | test(\"$OS_ARCH\")) | .browser_download_url")
+    if command -v jq > /dev/null 2>&1; then
+        DOWNLOAD_URL=$(echo "$RELEASE_INFO" | jq -r ".assets[] | select(.name | test(\"$OS_ARCH\")) | .browser_download_url")
+    elif command -v python3 > /dev/null 2>&1; then
+        DOWNLOAD_URL=$(echo "$RELEASE_INFO" | python3 -c "import sys, json; data = json.load(sys.stdin); print(next(asset['browser_download_url'] for asset in data['assets'] if '$OS_ARCH' in asset['name']))")
+    else
+        echo "Error: Neither jq or python3 is installed"
+    fi
 
     if [ -z "$DOWNLOAD_URL" ]; then
         echo "Error: No binary found for $OS_ARCH in the latest release."
@@ -30,7 +50,12 @@ install_binary() {
     fi
 
     echo "Downloading $BINARY_NAME from $DOWNLOAD_URL..."
-    wget -O "$BINARY_NAME" "$DOWNLOAD_URL"
+
+    if command -v wget > /dev/null 2>&1; then
+        wget -O "$BINARY_NAME" "$DOWNLOAD_URL"
+    else
+        curl -L -o "$BINARY_NAME" "$DOWNLOAD_URL"
+    fi
 
     if [ ! -f "$BINARY_NAME" ]; then
         echo "Error: Failed to download $BINARY_NAME."
@@ -38,6 +63,8 @@ install_binary() {
     fi
 
     echo "Installing $BINARY_NAME to $INSTALL_PATH..."
+
+    mkdir -p "$(dirname "$INSTALL_PATH")"
     mv "$BINARY_NAME" "$INSTALL_PATH"
 
     chmod +x "$INSTALL_PATH"
@@ -66,6 +93,12 @@ uninstall_binary() {
         exit 1
     fi
 
+    if [ "$PLATFORM" == "darwin" ]; then
+        CONFIG_DIR="$HOME/Library/Application Support/chibi"
+    else
+        CONFIG_DIR="$HOME/.config/chibi"
+    fi
+
     if [ -d "$CONFIG_DIR" ]; then
         echo "Removing $CONFIG_DIR directory..."
         rm -rf "$CONFIG_DIR"
@@ -80,6 +113,8 @@ uninstall_binary() {
         echo "No configuration directory found at $CONFIG_DIR."
     fi
 }
+
+
 
 if [ "$1" == "--uninstall" ]; then
     uninstall_binary

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ uninstall_binary() {
     if [ "$PLATFORM" == "darwin" ]; then
         CONFIG_DIR="$HOME/Library/Application Support/chibi"
     else
-        CONFIG_DIR="$HOME/.config/chibi"
+        CONFIG_DIR="/home/$SUDO_USER/.config/chibi"
     fi
 
     if [ -d "$CONFIG_DIR" ]; then


### PR DESCRIPTION
## Description

- Adds support for installing/uninstalling chibi on MacOS with the same install script for Linux.

- Should work on macOS 10.15 or later (`/usr/local/bin` isn't included in $PATH by default prior to this version I think). Though this script was only tested on macOS 13.

Since jq isn't preinstalled on mac systems, a fallback script with python is used to parse the download URL from JSON.
The python3 package comes bundled with command line tools for OS X 10.9 or later, so they must have that enabled or install jq.


## Type of change

Please delete options that are not relevant.

- [x] ✨ New feature (non-breaking change which adds functionality)

## Tested Environments
- [x] Linux (any distro)
- [ ] Windows (10 or 11)
- [ ] MacOS ARM64
- [x] MacOS Intel

## Checklist

- [x] I have used [Gitmojis](https://gitmoji.dev/) for my commit messages.
- [x] My code follows the [style guidelines](https://google.github.io/styleguide/go/) of the Go language.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (leave it unchecked if your changes doesn't need documentation update)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (Ignore this for now 🙂)
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules